### PR TITLE
Correct alpha computation for drawing buffer in composite pass.

### DIFF
--- a/src/WboitPass.js
+++ b/src/WboitPass.js
@@ -184,8 +184,10 @@ class WboitPass extends Pass {
 		this.compositePass.material.transparent = true;
 		this.compositePass.material.blending = CustomBlending;
 		this.compositePass.material.blendEquation = AddEquation;
-		this.compositePass.material.blendSrc = OneMinusSrcAlphaFactor;
-		this.compositePass.material.blendDst = SrcAlphaFactor;
+		this.compositePass.material.blendSrc = SrcAlphaFactor;
+		this.compositePass.material.blendDst = OneMinusSrcAlphaFactor;
+		this.compositePass.material.blendSrcAlpha = OneFactor
+		this.compositePass.material.blendDstAlpha = OneMinusSrcAlphaFactor;
 
 		const testPass = new ShaderPass( FillShader );
 		const testR = 1.0;

--- a/src/shaders/WboitCompositeShader.js
+++ b/src/shaders/WboitCompositeShader.js
@@ -49,7 +49,7 @@ const WboitCompositeShader = {
 
 			vec4 accum = texture2D( tAccumulation, vUv );
 
-			vec4 composite = vec4( accum.rgb / clamp( accum.a, 0.0001, 50000.0 ), reveal );
+			vec4 composite = vec4( accum.rgb / clamp( accum.a, 0.0001, 50000.0 ), 1.0 - reveal );
 			vec4 color = clamp( composite, 0.01, 300.0 );
 
 			// LinearTosRGB( color );


### PR DESCRIPTION
I encountered a problem rendering into a white canvas. Transparent objects were brighter than they should have been.

The issue was that the composite shader was not computing alpha on the destination correctly. It was actually reducing the transparency of the destination, which probably is never right.

The proposed solution is to complement the alpha in the composite, and then compute alpha as srcFactor=1, destFactor=1-srcAlpha.

I'm a newb in this area so I totally understand if this isn't the "right" fix.

Thanks!